### PR TITLE
multi-node configurable

### DIFF
--- a/cloudphish.py
+++ b/cloudphish.py
@@ -25,10 +25,6 @@ if __name__ == "__main__":
     parser.add_argument('-g', '--get', dest='sha256_content', help="get the cached content")
     args = parser.parse_args()
 
-    # ignore the proxy
-    #if 'https_proxy' in os.environ:
-    #    del os.environ['https_proxy']
-
     cp = cloudphish(profile=args.environment)
 
     if args.url:

--- a/cloudphish.py
+++ b/cloudphish.py
@@ -23,8 +23,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # ignore the proxy
-    if 'http_proxy' in os.environ:
-        del os.environ['https_proxy']
+    #if 'https_proxy' in os.environ:
+    #    del os.environ['https_proxy']
 
     cp = cloudphish()
 

--- a/cloudphish.py
+++ b/cloudphish.py
@@ -5,7 +5,7 @@ import sys
 import argparse
 import logging
 
-from cloudphishlib import cloudphish
+from cloudphishlib import cloudphish, load_config
 
 logging.basicConfig(level=logging.WARNING,
                     format='%(asctime)s - %(name)s - [%(levelname)s] %(message)s')
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
 
+    config = load_config()
+    profiles = config.sections()
     parser = argparse.ArgumentParser(description="simple user interface to cloudphish")
+    parser.add_argument('-e', '--environment', dest='environment', choices=profiles, default='default', help='select the ace cloudphish node you want to work with.')
     parser.add_argument('-s', '--submit', dest='url', help="submit a url/check on a url")
     parser.add_argument('-r', '--reprocess', action='store_true', help="make cloudphish reprocess a url")
     parser.add_argument('-a', '--alert', action='store_true', help="ACE alert if cloudphish finds a detection, and an alert hasn't already been generated")
@@ -26,7 +29,7 @@ if __name__ == "__main__":
     #if 'https_proxy' in os.environ:
     #    del os.environ['https_proxy']
 
-    cp = cloudphish()
+    cp = cloudphish(profile=args.environment)
 
     if args.url:
         print(cp.submit(args.url, reprocess=args.reprocess, alert=args.alert, text=True))

--- a/cloudphishlib/__init__.py
+++ b/cloudphishlib/__init__.py
@@ -11,8 +11,6 @@ def load_config(required_keys=[]):
     """Load cloudphish configuration. Configuration files are looked for in the following locations::
         /<python-lib-where-cloudphishlib-installed>/etc/ace_cloudphish.ini
         /etc/ace/cloudphish/ace_cloudphish.ini
-        /opt/ace/etc/saq.default.ini (looks for cloudphish.1 key)
-        /opt/ace/etc/saq.ini (looks for cloudphish.1 key)
         ~/<current-user>/.ace/cloudphish/ace_cloudphish.ini
 
     Configuration items found in later config files take presendence over earlier ones.
@@ -44,32 +42,19 @@ def load_config(required_keys=[]):
 
     config.read(finds)
     return config
-    """
-    try:
-        config[profile]
-    except KeyError:
-        logger.critical("No section named '{}' in configuration files : {}".format(profile, config_paths))
-        raise
-
-    if required_keys:
-        check_config(config, required_keys)
-    """
-    #return config
 
 
 # simple api for common cloudphish requests
 class cloudphish():
-    logger = logging.getLogger(__name__)
-    # path to ca_bundle that signed the server cert
-    # leaving True, means requests will still verify
-    #CA_BUNDLE_FILE = True
-    #if 'integral_ca_bundle' in os.environ:
-    #    CA_BUNDLE_FILE = os.environ['integral_ca_bundle']
-    #elif os.path.exists(os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')):
-    #    CA_BUNDLE_FILE = os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')
-    #else:
-    #    CA_BUNDLE_FILE = os.path.join('/','opt','ace','ssl','le-chain.pem')
+    """Simple ACE Cloudphish API wrapper.
 
+    :param str profile: Specify the ACE Cloudphish environment to work with. Default works with a localhost ACE install.
+    :param str server: (optional) specify a Cloudphish server address.
+    :param str port: (optional) specify the server port.
+    :param str ca_bundle_file_path: (optional) The path to the CA bundle file authoritative for the server.
+    """
+
+    logger = logging.getLogger(__name__)
     def __init__(self, profile='default', server=None, port=None, ca_bundle_file_path=None):
 
         self.config = load_config()

--- a/cloudphishlib/__init__.py
+++ b/cloudphishlib/__init__.py
@@ -6,31 +6,91 @@ import logging
 import requests
 from configparser import ConfigParser
 
+
+def load_config(required_keys=[]):
+    """Load cloudphish configuration. Configuration files are looked for in the following locations::
+        /<python-lib-where-cloudphishlib-installed>/etc/ace_cloudphish.ini
+        /etc/ace/cloudphish/ace_cloudphish.ini
+        /opt/ace/etc/saq.default.ini (looks for cloudphish.1 key)
+        /opt/ace/etc/saq.ini (looks for cloudphish.1 key)
+        ~/<current-user>/.ace/cloudphish/ace_cloudphish.ini
+
+    Configuration items found in later config files take presendence over earlier ones.
+
+    :param str profile: (optional) Specifiy a cloudphish node to work with.
+    :param list required_keys: (optional) A list of required config keys to check for
+    """
+
+    logger = logging.getLogger(__name__+".load_config")
+    config = ConfigParser()
+    config_paths = []
+    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # default
+    config_paths.append(os.path.join(BASE_DIR, 'etc', 'ace_cloudphish.ini'))
+    # global
+    config_paths.append('/etc/ace/cloudphish/ace_cloudphish.ini')
+    # legacy
+    #config_paths.append('/opt/cloudphishlib/etc/ace_cloudphish.ini')
+    # user specific
+    config_paths.append(os.path.join(os.path.expanduser("~"),'.ace', 'cloudphish', 'ace_cloudphish.ini'))
+    finds = []
+    for cp in config_paths:
+        if os.path.exists(cp):
+            logger.debug("Found config file at {}.".format(cp))
+            finds.append(cp)
+    if not finds:
+        logger.critical("Didn't find any config files defined at these paths: {}".format(config_paths))
+        raise Exception("MissingLercConfig", "Config paths : {}".format(config_paths))
+
+    config.read(finds)
+    return config
+    """
+    try:
+        config[profile]
+    except KeyError:
+        logger.critical("No section named '{}' in configuration files : {}".format(profile, config_paths))
+        raise
+
+    if required_keys:
+        check_config(config, required_keys)
+    """
+    #return config
+
+
 # simple api for common cloudphish requests
 class cloudphish():
-    server = 'cloudphish1.local'
-    port = 5000
-    base_url = 'https://{}:{}/'.format(server, port)
     logger = logging.getLogger(__name__)
     # path to ca_bundle that signed the server cert
     # leaving True, means requests will still verify
-    CA_BUNDLE_FILE = True
-    if 'integral_ca_bundle' in os.environ:
-        CA_BUNDLE_FILE = os.environ['integral_ca_bundle']
-    elif os.path.exists(os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')):
-        CA_BUNDLE_FILE = os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')
+    #CA_BUNDLE_FILE = True
+    #if 'integral_ca_bundle' in os.environ:
+    #    CA_BUNDLE_FILE = os.environ['integral_ca_bundle']
+    #elif os.path.exists(os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')):
+    #    CA_BUNDLE_FILE = os.path.join('/','usr','local','share','ca-certificates','integral-ca.pem')
+    #else:
+    #    CA_BUNDLE_FILE = os.path.join('/','opt','ace','ssl','le-chain.pem')
 
-    def __init__(self, server=None, port=None, ca_bundle_file_path=None):
+    def __init__(self, profile='default', server=None, port=None, ca_bundle_file_path=None):
+
+        self.config = load_config()
+        self.server = self.config[profile]['server']
+        self.port = self.config[profile]['port']
+        self.CA_BUNDLE_FILE = self.config[profile]['ca_bundle_file']
         if server:
             self.server = server
         if port:
             self.port = port
         if ca_bundle_file_path:
             self.CA_BUNDLE_FILE = ca_bundle_file_path
+        self.base_url = 'https://{}:{}/'.format(self.server, self.port)
+        if self.config[profile].getboolean('ignore_system_proxy'):
+            if 'https_proxy' in os.environ:
+                del os.environ['https_proxy']
+
 
     def submit(self, url, reprocess=False, alert=False, text=False):
         self.logger.debug("checking on '{}'".format(url))
-        path = os.path.join('saq','cloudphish','submit')
+        path = os.path.join('api','cloudphish','submit')
         arguments = {'url': url}
         if alert:
             arguments['a'] = 1
@@ -45,7 +105,7 @@ class cloudphish():
 
     def get(self, sha256, compress=False):
         self.logger.debug("downloading content for: {}".format(sha256))
-        path = os.path.join('saq','cloudphish')
+        path = os.path.join('api','cloudphish')
         if compress:
             path = os.path.join(path, 'download_alert')
         else:
@@ -61,7 +121,7 @@ class cloudphish():
 
     def clear(self, url):
         self.logger.debug("Clearing chached results for : '{}'".format(url))
-        path = os.path.join('saq','cloudphish','clear_alert')
+        path = os.path.join('api','cloudphish','clear_alert')
         arguments = {'url': url}
 
         r = requests.get(self.base_url + path, params=arguments, verify=self.CA_BUNDLE_FILE)

--- a/etc/ace_cloudphish.ini
+++ b/etc/ace_cloudphish.ini
@@ -1,0 +1,5 @@
+[default]
+server = localhost
+port = 443
+ca_bundle_file = /opt/ace/ssl/ca-chain.cert.pem
+ignore_system_proxy = yes


### PR DESCRIPTION
Default: works with a locally installed ACE running cloudphish.

Configuration settings override each other in the following order:

-  /{where-cloudphishlib-installed}/etc/ace_cloudphish.ini
- /etc/ace/cloudphish/ace_cloudphish.ini
- ~/{current-user}/.ace/cloudphish/ace_cloudphish.ini

